### PR TITLE
remove deprecated usage of BigDecimal.new

### DIFF
--- a/lib/symbolized/core_ext/object/duplicable.rb
+++ b/lib/symbolized/core_ext/object/duplicable.rb
@@ -83,7 +83,7 @@ unless defined? ActiveSupport
     # raises TypeError exception. Checking here on the runtime whether BigDecimal
     # will allow dup or not.
     begin
-      BigDecimal.new('4.56').dup
+      BigDecimal('4.56').dup
 
       def duplicable?
         true


### PR DESCRIPTION
`BigDecimal.new` is deprecated since Ruby 2.6 and was removed in Ruby 2.7. Using `BigDecimal('123')` is backward compatible down to Ruby 1.9.3 (oldest version in the CI yml), see https://apidock.com/ruby/v1_9_1_378/BigDecimal, hence this change should be fine.

We need this for https://github.com/TamerShlash/symbolized/pull/4 to pass the CI.